### PR TITLE
Replace Sandpack with Monaco Editor + Web Worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,6 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
-    <script type="module" defer src="/src/config/removeWatermark.js"></script>
+
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "algorithms-and-data-structures",
 			"version": "1.0.0",
 			"dependencies": {
-				"@codesandbox/sandpack-react": "^2.18.2",
+				"@monaco-editor/react": "^4.7.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"react-router-dom": "^6.26.0"
@@ -200,178 +200,6 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
-			}
-		},
-		"node_modules/@codemirror/autocomplete": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.0.tgz",
-			"integrity": "sha512-5DbOvBbY4qW5l57cjDsmmpDh3/TeK1vXfTHa+BUMrRzdWdcxKZ4U4V7vQaTtOpApNU4kLS4FQ6cINtLg245LXA==",
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/language": "^6.0.0",
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.17.0",
-				"@lezer/common": "^1.0.0"
-			},
-			"peerDependencies": {
-				"@codemirror/language": "^6.0.0",
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0",
-				"@lezer/common": "^1.0.0"
-			}
-		},
-		"node_modules/@codemirror/commands": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.6.0.tgz",
-			"integrity": "sha512-qnY+b7j1UNcTS31Eenuc/5YJB6gQOzkUoNmJQc0rznwqSRpeaWWpjkWy2C/MPTcePpsKJEM26hXrOXl1+nceXg==",
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/language": "^6.0.0",
-				"@codemirror/state": "^6.4.0",
-				"@codemirror/view": "^6.27.0",
-				"@lezer/common": "^1.1.0"
-			}
-		},
-		"node_modules/@codemirror/lang-css": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.2.1.tgz",
-			"integrity": "sha512-/UNWDNV5Viwi/1lpr/dIXJNWiwDxpw13I4pTUAsNxZdg6E0mI2kTQb0P2iHczg1Tu+H4EBgJR+hYhKiHKko7qg==",
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/autocomplete": "^6.0.0",
-				"@codemirror/language": "^6.0.0",
-				"@codemirror/state": "^6.0.0",
-				"@lezer/common": "^1.0.2",
-				"@lezer/css": "^1.0.0"
-			}
-		},
-		"node_modules/@codemirror/lang-html": {
-			"version": "6.4.9",
-			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.9.tgz",
-			"integrity": "sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/autocomplete": "^6.0.0",
-				"@codemirror/lang-css": "^6.0.0",
-				"@codemirror/lang-javascript": "^6.0.0",
-				"@codemirror/language": "^6.4.0",
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.17.0",
-				"@lezer/common": "^1.0.0",
-				"@lezer/css": "^1.1.0",
-				"@lezer/html": "^1.3.0"
-			}
-		},
-		"node_modules/@codemirror/lang-javascript": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.2.tgz",
-			"integrity": "sha512-VGQfY+FCc285AhWuwjYxQyUQcYurWlxdKYT4bqwr3Twnd5wP5WSeu52t4tvvuWmljT4EmgEgZCqSieokhtY8hg==",
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/autocomplete": "^6.0.0",
-				"@codemirror/language": "^6.6.0",
-				"@codemirror/lint": "^6.0.0",
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.17.0",
-				"@lezer/common": "^1.0.0",
-				"@lezer/javascript": "^1.0.0"
-			}
-		},
-		"node_modules/@codemirror/language": {
-			"version": "6.10.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.2.tgz",
-			"integrity": "sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==",
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.23.0",
-				"@lezer/common": "^1.1.0",
-				"@lezer/highlight": "^1.0.0",
-				"@lezer/lr": "^1.0.0",
-				"style-mod": "^4.0.0"
-			}
-		},
-		"node_modules/@codemirror/lint": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.1.tgz",
-			"integrity": "sha512-IZ0Y7S4/bpaunwggW2jYqwLuHj0QtESf5xcROewY6+lDNwZ/NzvR4t+vpYgg9m7V8UXLPYqG+lu3DF470E5Oxg==",
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0",
-				"crelt": "^1.0.5"
-			}
-		},
-		"node_modules/@codemirror/state": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
-			"integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
-			"license": "MIT"
-		},
-		"node_modules/@codemirror/view": {
-			"version": "6.32.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.32.0.tgz",
-			"integrity": "sha512-AgVNvED2QTsZp5e3syoHLsrWtwJFYWdx1Vr/m3f4h1ATQz0ax60CfXF3Htdmk69k2MlYZw8gXesnQdHtzyVmAw==",
-			"license": "MIT",
-			"dependencies": {
-				"@codemirror/state": "^6.4.0",
-				"style-mod": "^4.1.0",
-				"w3c-keyname": "^2.2.4"
-			}
-		},
-		"node_modules/@codesandbox/nodebox": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/@codesandbox/nodebox/-/nodebox-0.1.8.tgz",
-			"integrity": "sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==",
-			"license": "SEE LICENSE IN ./LICENSE",
-			"dependencies": {
-				"outvariant": "^1.4.0",
-				"strict-event-emitter": "^0.4.3"
-			}
-		},
-		"node_modules/@codesandbox/sandpack-client": {
-			"version": "2.18.2",
-			"resolved": "https://registry.npmjs.org/@codesandbox/sandpack-client/-/sandpack-client-2.18.2.tgz",
-			"integrity": "sha512-zKSZWoCqpUFHqSbG1Q88ICqbY/nKKTY3rKKxTdNCSv0miI3JAR671kFcq6fkoCYVHFg6WIVpW7EzYwA/TYzX0w==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@codesandbox/nodebox": "0.1.8",
-				"buffer": "^6.0.3",
-				"dequal": "^2.0.2",
-				"mime-db": "^1.52.0",
-				"outvariant": "1.4.0",
-				"static-browser-server": "1.0.3"
-			}
-		},
-		"node_modules/@codesandbox/sandpack-react": {
-			"version": "2.18.2",
-			"resolved": "https://registry.npmjs.org/@codesandbox/sandpack-react/-/sandpack-react-2.18.2.tgz",
-			"integrity": "sha512-OvXHAUKTjqXfjB9qd+6Pt3Pzjpk2/SRxVFUAC7cRwnSap3X7T0uBDdoRIJTlueXVrD+F1FkaGRzIE5GgGm4FEQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@codemirror/autocomplete": "^6.4.0",
-				"@codemirror/commands": "^6.1.3",
-				"@codemirror/lang-css": "^6.0.1",
-				"@codemirror/lang-html": "^6.4.0",
-				"@codemirror/lang-javascript": "^6.1.2",
-				"@codemirror/language": "^6.3.2",
-				"@codemirror/state": "^6.2.0",
-				"@codemirror/view": "^6.7.1",
-				"@codesandbox/sandpack-client": "^2.18.2",
-				"@lezer/highlight": "^1.1.3",
-				"@react-hook/intersection-observer": "^3.1.1",
-				"@stitches/core": "^1.2.6",
-				"anser": "^2.1.1",
-				"clean-set": "^1.1.2",
-				"dequal": "^2.0.2",
-				"escape-carriage": "^1.3.1",
-				"lz-string": "^1.4.4",
-				"react-devtools-inline": "4.4.0",
-				"react-is": "^17.0.2"
-			},
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17 || ^18",
-				"react-dom": "^16.8.0 || ^17 || ^18"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -836,61 +664,27 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@lezer/common": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
-			"integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==",
-			"license": "MIT"
-		},
-		"node_modules/@lezer/css": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.8.tgz",
-			"integrity": "sha512-7JhxupKuMBaWQKjQoLtzhGj83DdnZY9MckEOG5+/iLKNK2ZJqKc6hf6uc0HjwCX7Qlok44jBNqZhHKDhEhZYLA==",
+		"node_modules/@monaco-editor/loader": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+			"integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
 			"license": "MIT",
 			"dependencies": {
-				"@lezer/common": "^1.2.0",
-				"@lezer/highlight": "^1.0.0",
-				"@lezer/lr": "^1.0.0"
+				"state-local": "^1.0.6"
 			}
 		},
-		"node_modules/@lezer/highlight": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
-			"integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+		"node_modules/@monaco-editor/react": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+			"integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
 			"license": "MIT",
 			"dependencies": {
-				"@lezer/common": "^1.0.0"
-			}
-		},
-		"node_modules/@lezer/html": {
-			"version": "1.3.10",
-			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.10.tgz",
-			"integrity": "sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==",
-			"license": "MIT",
-			"dependencies": {
-				"@lezer/common": "^1.2.0",
-				"@lezer/highlight": "^1.0.0",
-				"@lezer/lr": "^1.0.0"
-			}
-		},
-		"node_modules/@lezer/javascript": {
-			"version": "1.4.17",
-			"resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.17.tgz",
-			"integrity": "sha512-bYW4ctpyGK+JMumDApeUzuIezX01H76R1foD6LcRX224FWfyYit/HYxiPGDjXXe/wQWASjCvVGoukTH68+0HIA==",
-			"license": "MIT",
-			"dependencies": {
-				"@lezer/common": "^1.2.0",
-				"@lezer/highlight": "^1.1.3",
-				"@lezer/lr": "^1.3.0"
-			}
-		},
-		"node_modules/@lezer/lr": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
-			"integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
-			"license": "MIT",
-			"dependencies": {
-				"@lezer/common": "^1.0.0"
+				"@monaco-editor/loader": "^1.5.0"
+			},
+			"peerDependencies": {
+				"monaco-editor": ">= 0.25.0 < 1",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -931,12 +725,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@open-draft/deferred-promise": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-			"integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-			"license": "MIT"
-		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -946,28 +734,6 @@
 			"optional": true,
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/@react-hook/intersection-observer": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@react-hook/intersection-observer/-/intersection-observer-3.1.2.tgz",
-			"integrity": "sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@react-hook/passive-layout-effect": "^1.2.0",
-				"intersection-observer": "^0.10.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.8"
-			}
-		},
-		"node_modules/@react-hook/passive-layout-effect": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
-			"integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": ">=16.8"
 			}
 		},
 		"node_modules/@remix-run/router": {
@@ -1202,12 +968,6 @@
 			"os": [
 				"win32"
 			]
-		},
-		"node_modules/@stitches/core": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
-			"integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==",
-			"license": "MIT"
 		},
 		"node_modules/@swc/core": {
 			"version": "1.7.11",
@@ -1470,6 +1230,13 @@
 				"@types/react": "*"
 			}
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/@vitejs/plugin-react-swc": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.0.tgz",
@@ -1482,12 +1249,6 @@
 			"peerDependencies": {
 				"vite": "^4 || ^5"
 			}
-		},
-		"node_modules/anser": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/anser/-/anser-2.1.1.tgz",
-			"integrity": "sha512-nqLm4HxOTpeLOxcmB3QWmV5TcDFhW9y/fyQ+hivtDFcK4OQ+pQ5fzPnXHM1Mfcm0VkLtvVi1TCPr++Qy0Q/3EQ==",
-			"license": "MIT"
 		},
 		"node_modules/ansi-regex": {
 			"version": "6.0.1",
@@ -1588,26 +1349,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1664,6 +1405,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001646",
 				"electron-to-chromium": "^1.5.4",
@@ -1675,30 +1417,6 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			}
-		},
-		"node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/camelcase-css": {
@@ -1770,12 +1488,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/clean-set": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/clean-set/-/clean-set-1.1.2.tgz",
-			"integrity": "sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==",
-			"license": "MIT"
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1805,12 +1517,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/crelt": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -1847,28 +1553,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/d": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
-			"integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
-			"license": "ISC",
-			"dependencies": {
-				"es5-ext": "^0.10.64",
-				"type": "^2.7.2"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
-		"node_modules/dequal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1883,16 +1567,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/dotenv": {
-			"version": "16.4.5",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
+		"node_modules/dompurify": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+			"integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/eastasianwidth": {
@@ -1915,46 +1596,6 @@
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/es5-ext": {
-			"version": "0.10.64",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-			"integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-			"hasInstallScript": true,
-			"license": "ISC",
-			"dependencies": {
-				"es6-iterator": "^2.0.3",
-				"es6-symbol": "^3.1.3",
-				"esniff": "^2.0.1",
-				"next-tick": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-			"license": "MIT",
-			"dependencies": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"node_modules/es6-symbol": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
-			"integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
-			"license": "ISC",
-			"dependencies": {
-				"d": "^1.0.2",
-				"ext": "^1.7.0"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.21.5",
@@ -2003,46 +1644,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/escape-carriage": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
-			"integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==",
-			"license": "MIT"
-		},
-		"node_modules/esniff": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-			"integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-			"license": "ISC",
-			"dependencies": {
-				"d": "^1.0.1",
-				"es5-ext": "^0.10.62",
-				"event-emitter": "^0.3.5",
-				"type": "^2.7.2"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/event-emitter": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-			"license": "MIT",
-			"dependencies": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
-			}
-		},
-		"node_modules/ext": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-			"integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-			"license": "ISC",
-			"dependencies": {
-				"type": "^2.7.2"
 			}
 		},
 		"node_modules/fast-glob": {
@@ -2214,32 +1815,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/intersection-observer": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
-			"integrity": "sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==",
-			"license": "W3C-20150513"
-		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2387,13 +1962,16 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/lz-string": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+		"node_modules/marked": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+			"integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
 			"license": "MIT",
 			"bin": {
-				"lz-string": "bin/bin.js"
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/merge2": {
@@ -2420,15 +1998,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/mime-db": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-			"integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -2453,6 +2022,17 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/monaco-editor": {
+			"version": "0.55.1",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+			"integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"dompurify": "3.2.7",
+				"marked": "14.0.0"
 			}
 		},
 		"node_modules/mz": {
@@ -2485,12 +2065,6 @@
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
-		},
-		"node_modules/next-tick": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-			"license": "ISC"
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.18",
@@ -2538,12 +2112,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/outvariant": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
-			"integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
-			"license": "MIT"
 		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.0",
@@ -2646,6 +2214,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.1",
@@ -2815,6 +2384,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -2822,20 +2392,12 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/react-devtools-inline": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz",
-			"integrity": "sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==",
-			"license": "MIT",
-			"dependencies": {
-				"es6-symbol": "^3"
-			}
-		},
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -2843,12 +2405,6 @@
 			"peerDependencies": {
 				"react": "^18.3.1"
 			}
-		},
-		"node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"license": "MIT"
 		},
 		"node_modules/react-router": {
 			"version": "6.26.1",
@@ -3049,22 +2605,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/static-browser-server": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
-			"integrity": "sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@open-draft/deferred-promise": "^2.1.0",
-				"dotenv": "^16.0.3",
-				"mime-db": "^1.52.0",
-				"outvariant": "^1.3.0"
-			}
-		},
-		"node_modules/strict-event-emitter": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
-			"integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+		"node_modules/state-local": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+			"integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
 			"license": "MIT"
 		},
 		"node_modules/string-width": {
@@ -3170,12 +2714,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/style-mod": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
-			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
-			"license": "MIT"
 		},
 		"node_modules/sucrase": {
 			"version": "3.35.0",
@@ -3294,12 +2832,6 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/type": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-			"integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-			"license": "ISC"
-		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
@@ -3344,6 +2876,7 @@
 			"integrity": "sha512-1oE6yuNXssjrZdblI9AfBbHCC41nnyoVoEZxQnID6yvQZAFBzxxkqoFLtHUMkYunL8hwOLEjgTuxpkRxvba3kA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.41",
@@ -3397,12 +2930,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/w3c-keyname": {
-			"version": "2.2.8",
-			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-			"license": "MIT"
 		},
 		"node_modules/which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"@codesandbox/sandpack-react": "^2.18.2",
+		"@monaco-editor/react": "^4.7.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"react-router-dom": "^6.26.0"
 	},
 	"devDependencies": {
+		"@biomejs/biome": "^1.8.3",
 		"@types/react": "^18.3.3",
 		"@types/react-dom": "^18.3.0",
 		"@vitejs/plugin-react-swc": "^3.5.0",
 		"autoprefixer": "^10.4.20",
-		"@biomejs/biome": "^1.8.3",
 		"globals": "^15.9.0",
 		"postcss": "^8.4.41",
 		"tailwindcss": "^3.4.10",

--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import Editor from "@monaco-editor/react";
+
+const DEBOUNCE_MS = 500;
+
+function isHTML(value) {
+    return typeof value === "string" && /<[a-z][\s\S]*>/i.test(value);
+}
+
+function Preview({ result, logs, error }) {
+    if (error) {
+        return <pre className="p-4 text-sm text-red-400 whitespace-pre-wrap">{error}</pre>;
+    }
+
+    const htmlResult = isHTML(result);
+
+    return (
+        <div className="flex flex-col h-full">
+            {htmlResult ? (
+                <iframe
+                    className="w-full flex-1"
+                    srcDoc={`<html><body style="margin:8px;font-family:sans-serif;">${result}</body></html>`}
+                    sandbox="allow-scripts"
+                    title="preview"
+                />
+            ) : (
+                <div className="p-4 font-mono text-sm flex-1 overflow-auto">
+                    {logs.map((log, i) => (
+                        <div key={i} className="text-gray-600">{log}</div>
+                    ))}
+                    {result !== null && (
+                        <div className="text-green-700">
+                            {typeof result === "object"
+                                ? JSON.stringify(result, null, 2)
+                                : String(result)}
+                        </div>
+                    )}
+                </div>
+            )}
+            {htmlResult && logs.length > 0 && (
+                <div className="border-t border-gray-700 p-4 font-mono text-sm overflow-auto max-h-32">
+                    {logs.map((log, i) => (
+                        <div key={i} className="text-gray-600">{log}</div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function CodeEditor({ code, filename = "Example.js" }) {
+    const [editorCode, setEditorCode] = useState(code);
+    const [result, setResult] = useState(null);
+    const [logs, setLogs] = useState([]);
+    const [error, setError] = useState(null);
+    const workerRef = useRef(null);
+    const debounceRef = useRef(null);
+
+    const runCode = useCallback((codeToRun) => {
+        if (workerRef.current) workerRef.current.terminate();
+
+        workerRef.current = new Worker(
+            new URL("../workers/codeRunner.js", import.meta.url)
+        );
+
+        workerRef.current.onmessage = (e) => {
+            setResult(e.data.result);
+            setLogs(e.data.logs);
+            setError(e.data.error);
+        };
+
+        workerRef.current.postMessage({ code: codeToRun });
+    }, []);
+
+    useEffect(() => {
+        runCode(editorCode);
+        return () => {
+            if (workerRef.current) workerRef.current.terminate();
+            clearTimeout(debounceRef.current);
+        };
+    }, []);
+
+    const handleChange = (value) => {
+        setEditorCode(value);
+        clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => runCode(value), DEBOUNCE_MS);
+    };
+
+    return (
+        <div
+            className="flex border border-gray-700 rounded overflow-hidden"
+            style={{ height: 500 }}
+        >
+            <div style={{ width: "70%" }} className="flex flex-col">
+                <div className="bg-gray-800 text-gray-400 text-xs px-3 py-1 border-b border-gray-700 shrink-0">
+                    {filename}
+                </div>
+                <Editor
+                    height="100%"
+                    defaultLanguage="javascript"
+                    theme="vs-dark"
+                    value={editorCode}
+                    onChange={handleChange}
+                    options={{
+                        lineNumbers: "on",
+                        minimap: { enabled: false },
+                        scrollBeyondLastLine: false,
+                        wordWrap: "on",
+                        fontSize: 13,
+                    }}
+                />
+            </div>
+            <div
+                className="flex flex-col bg-white border-l border-gray-700"
+                style={{ width: "30%" }}
+            >
+                <div className="bg-gray-800 text-gray-400 text-xs px-3 py-1 border-b border-gray-300 shrink-0">
+                    Preview
+                </div>
+                <div className="flex-1 overflow-auto">
+                    <Preview result={result} logs={logs} error={error} />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default CodeEditor;

--- a/src/config/removeWatermark.js
+++ b/src/config/removeWatermark.js
@@ -1,9 +1,0 @@
-const removeWatermark = () => {
-    const buttons = document.body.querySelectorAll('button');
-    for (const button of buttons) {
-        if (button.title.startsWith('Open in'))
-            button.style.display = 'none';
-    }
-};
-
-setTimeout(removeWatermark, 5000);

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -1,45 +1,16 @@
-/**
- * Sandpack Configuration Options
- * 
- * This file contains the configuration settings for Sandpack.
- */
-
-const sandPackOptions = {
-    visibleFiles: ["Example.js"],
-    activeFile: "Example.js",
-    initMode: "lazy", // Load Sandpack lazily
-    showLineNumbers: true, // Show line numbers in the editor
-    autorun: true, // Automatically run the code
-    autoReload: true, // Automatically reload the code on changes
-    recompileMode: "delayed", // Delay recompilation
-    recompileDelay: 500, // Delay in milliseconds for recompilation
-    logLevel: "info", // Logging level
-    skipEval: false, // Do not skip evaluation
-    externalResources: [], // List of external resources
-    showInlineErrors: true, // Show inline errors in the editor
-    wrapContent: true, // Wrap content in the editor
-    layout: "preview", // Layout mode: "preview" | "tests" | "console"
-    editorHeight: 500, // Height of the editor in pixels
-    editorWidthPercentage: 70, // Width of the editor as a percentage
-    resizablePanels: true, // Allow resizing of panels
-    wrapCodeInFunction: true, // Wrap code in a function
+const editorOptions = {
+    lineNumbers: "on",
+    minimap: { enabled: false },
+    scrollBeyondLastLine: false,
+    wordWrap: "on",
+    fontSize: 13,
 };
 
-function wrapInFunction(code) {
-    return `function example() {\n${code}\n}`;
-}
-
-const sandPackProps = {
-    template: "node", // Template type
-    theme: "dark", // Theme for the editor
-    autoRun: true, // Automatically run the code
-    options: sandPackOptions, // Sandpack options
-    showNavigation: true, // Show navigation bar
-    wrapCodeInFunction: wrapInFunction, // Wrap code in a function
+const editorDefaults = {
+    theme: "vs-dark",
+    language: "javascript",
+    height: 500,
+    previewWidthPercent: 30,
 };
 
-export {
-    sandPackProps,
-    sandPackOptions,
-    wrapInFunction
-};
+export { editorDefaults, editorOptions };

--- a/src/pages/BinarySearch.jsx
+++ b/src/pages/BinarySearch.jsx
@@ -1,8 +1,6 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/BinarySearch/Example.js?raw";
-import index from "../examples/BinarySearch/index.js?raw";
-import { sandPackOptions, sandPackProps } from "../config/settings";
 
 function DepthFirstSearch() {
 	return (
@@ -16,19 +14,7 @@ function DepthFirstSearch() {
 				the use of the proper search algorithm.
 			</p>
 
-			<Sandpack
-				files={{
-					
-					"Example.js": Example,
-					"index.js": index,
-				}}
-				customSetup={{ entry: index }}
-				options={sandPackOptions}
-				template={sandPackProps.template}
-				theme={sandPackProps.theme}
-				autoRun={sandPackProps.autoRun}
-				showNavigation={sandPackProps.showNavigation}
-			/>
+			<CodeEditor code={Example} />
 		</>
 	);
 }

--- a/src/pages/DepthFirstSearch.jsx
+++ b/src/pages/DepthFirstSearch.jsx
@@ -1,8 +1,6 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/DepthFirstSearch/Example.js?raw";
-import index from "../examples/DepthFirstSearch/index.js?raw";
-import { sandPackOptions, sandPackProps } from "../config/settings";
 
 function DepthFirstSearch() {
 	return (
@@ -14,18 +12,7 @@ function DepthFirstSearch() {
 				explores as far as possible along each branch before backtracking.
 			</p>
 
-			<Sandpack
-				files={{
-					"Example.js": Example,
-					"index.js": index,
-				}}
-				customSetup={{ entry: index }}
-				options={sandPackOptions}
-				template={sandPackProps.template}
-				theme={sandPackProps.theme}
-				autoRun={sandPackProps.autoRun}
-				showNavigation={sandPackProps.showNavigation}
-			/>
+			<CodeEditor code={Example} />
 		</>
 	);
 }

--- a/src/pages/Graphs.jsx
+++ b/src/pages/Graphs.jsx
@@ -1,8 +1,6 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/Graphs/Example.js?raw";
-import index from "../examples/Graphs/index.js?raw";
-import { sandPackOptions, sandPackProps } from "../config/settings";
 
 function Graphs() {
 	return (
@@ -13,18 +11,7 @@ function Graphs() {
 				nodes) and a set of edges (or connections) between them.
 			</p>
 
-			<Sandpack
-				files={{
-					"Example.js": Example,
-					"index.js": index,
-				}}
-				customSetup={{ entry: index }}
-				options={sandPackOptions}
-				template={sandPackProps.template}
-				theme={sandPackProps.theme}
-				autoRun={sandPackProps.autoRun}
-				showNavigation={sandPackProps.showNavigation}
-			/>
+			<CodeEditor code={Example} />
 		</>
 	);
 }

--- a/src/pages/Greedy.jsx
+++ b/src/pages/Greedy.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/Greedy/Example.js?raw";
-import index from "../examples/Greedy/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function Queues() {
   return (
@@ -174,20 +173,7 @@ function Queues() {
         </p>
       </div>
 
-      <Sandpack
-        template="node"
-        theme="dark"
-        files={{
-          "Example.js": Example,
-          "index.js": index,
-        }}
-        customSetup={{
-          entry: index,
-        }}
-        autoRun={true}
-        options={sandPackOptions}
-        showNavigation={true}
-      />
+      <CodeEditor code={Example} />
     </div>
   );
 }

--- a/src/pages/HashMaps.jsx
+++ b/src/pages/HashMaps.jsx
@@ -1,8 +1,6 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/HashMaps/Example.js?raw";
-import index from "../examples/HashMaps/index.js?raw";
-import { sandPackOptions, sandPackProps } from "../config/settings";
 
 function HashMaps() {
 	return (
@@ -15,18 +13,7 @@ function HashMaps() {
 				used as a key or a value.
 			</p>
 
-			<Sandpack
-				files={{
-					"Example.js": Example,
-					"index.js": index,
-				}}
-				customSetup={{ entry: index }}
-				options={sandPackOptions}
-				template={sandPackProps.template}
-				theme={sandPackProps.theme}
-				autoRun={sandPackProps.autoRun}
-				showNavigation={sandPackProps.showNavigation}
-			/>
+			<CodeEditor code={Example} />
 		</div>
 	);
 }

--- a/src/pages/HashString.jsx
+++ b/src/pages/HashString.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/HashString/Example.js?raw";
-import index from "../examples/HashString/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function HashString() {
   return (
@@ -15,20 +14,7 @@ function HashString() {
         changes to the input data will produce a completely different hash.
       </p>
 
-      <Sandpack
-        template="node"
-        theme="dark"
-        files={{
-          "Example.js": Example,
-          "index.js": index,
-        }}
-        customSetup={{
-          entry: index,
-        }}
-        autoRun={true}
-        options={sandPackOptions}
-        showNavigation={true}
-      />
+      <CodeEditor code={Example} />
     </div>
   );
 }

--- a/src/pages/HeapSort.jsx
+++ b/src/pages/HeapSort.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/HeapSort/Example.js?raw";
-import index from "../examples/HeapSort/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function HeapSort() {
   return (
@@ -24,20 +23,7 @@ function HeapSort() {
         repeated until the entire array is sorted.
       </p>
 
-      <Sandpack
-        template="node"
-        theme="dark"
-        files={{
-          "Example.js": Example,
-          "index.js": index,
-        }}
-        customSetup={{
-          entry: index,
-        }}
-        autoRun={true}
-        options={sandPackOptions}
-        showNavigation={true}
-      />
+      <CodeEditor code={Example} />
     </div>
   );
 }

--- a/src/pages/LinkedList.jsx
+++ b/src/pages/LinkedList.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/LinkedList/Example.js?raw";
-import index from "../examples/LinkedList/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function LinkedListPage() {
   return (
@@ -14,20 +13,7 @@ function LinkedListPage() {
         of data elements, with each element pointing to the next.
       </p>
 
-      <Sandpack
-        template="node"
-        theme="dark"
-        files={{
-          "Example.js": Example,
-          "index.js": index,
-        }}
-        customSetup={{
-          entry: index,
-        }}
-        autoRun={true}
-        options={sandPackOptions}
-        showNavigation={true}
-      />
+      <CodeEditor code={Example} />
     </div>
   );
 }

--- a/src/pages/MergeSort.jsx
+++ b/src/pages/MergeSort.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/MergeSort/Example.js?raw";
-import index from "../examples/MergeSort/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function MergeSort() {
   return (
@@ -14,20 +13,7 @@ function MergeSort() {
         into a single sorted array.
       </p>
 
-      <Sandpack
-        template="node"
-        theme="dark"
-        files={{
-          "Example.js": Example,
-          "index.js": index,
-        }}
-        customSetup={{
-          entry: index,
-        }}
-        autoRun={true}
-        options={sandPackOptions}
-        showNavigation={true}
-      />
+      <CodeEditor code={Example} />
     </div>
   );
 }

--- a/src/pages/Queues.jsx
+++ b/src/pages/Queues.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/Queues/Example.js?raw";
-import index from "../examples/Queues/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function Queues() {
   return (
@@ -12,20 +11,7 @@ function Queues() {
         A queue follows the First In First Out (FIFO) principle
       </p>
 
-      <Sandpack
-        template="node"
-        theme="dark"
-        files={{
-          "Example.js": Example,
-          "index.js": index,
-        }}
-        customSetup={{
-          entry: index,
-        }}
-        autoRun={true}
-        options={sandPackOptions}
-        showNavigation={true}
-      />
+      <CodeEditor code={Example} />
     </div>
   );
 }

--- a/src/pages/QuickSort.jsx
+++ b/src/pages/QuickSort.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/QuickSort/Example.js?raw";
-import index from "../examples/QuickSort/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function QuickSort() {
   return (
@@ -30,20 +29,7 @@ function QuickSort() {
         numbers and pass it to the quickSort() function.
       </p>
 
-      <Sandpack
-        template="node"
-        theme="dark"
-        files={{
-          "Example.js": Example,
-          "index.js": index,
-        }}
-        customSetup={{
-          entry: index,
-        }}
-        autoRun={true}
-        options={sandPackOptions}
-        showNavigation={true}
-      />
+      <CodeEditor code={Example} />
     </div>
   );
 }

--- a/src/pages/Sets.jsx
+++ b/src/pages/Sets.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/Sets/Example.js?raw";
-import index from "../examples/Sets/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function Sets() {
   return (
@@ -20,20 +19,7 @@ function Sets() {
         set operations like union, intersection, and difference.
       </p>
 
-      <Sandpack
-        template="node"
-        theme="dark"
-        files={{
-          "Example.js": Example,
-          "index.js": index,
-        }}
-        customSetup={{
-          entry: index,
-        }}
-        autoRun={true}
-        options={sandPackOptions}
-        showNavigation={true}
-      />
+      <CodeEditor code={Example} />
     </div>
   );
 }

--- a/src/pages/Stack.jsx
+++ b/src/pages/Stack.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/Stack/Example.js?raw";
-import index from "../examples/Stack/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function Stack() {
   return (
@@ -12,20 +11,7 @@ function Stack() {
         A stack follows the Last-In-First-Out (LIFO) principle
       </p>
 
-      <Sandpack
-        template="node"
-        theme="dark"
-        files={{
-          "Example.js": Example,
-          "index.js": index,
-        }}
-        customSetup={{
-          entry: index,
-        }}
-        autoRun={true}
-        options={sandPackOptions}
-        showNavigation={true}
-      />
+      <CodeEditor code={Example} />
     </div>
   );
 }

--- a/src/pages/TowerHanoi.jsx
+++ b/src/pages/TowerHanoi.jsx
@@ -1,8 +1,6 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/TowerHanoi/Example.js?raw";
-import index from "../examples/TowerHanoi/index.js?raw";
-import { sandPackOptions, sandPackProps } from "../config/settings";
 
 function Stack() {
 	return (
@@ -28,18 +26,7 @@ function Stack() {
 				</a>
 			</p>
 
-			<Sandpack
-				files={{
-					"Example.js": Example,
-					"index.js": index,
-				}}
-				customSetup={{ entry: index }}
-				options={sandPackOptions}
-				template={sandPackProps.template}
-				theme={sandPackProps.theme}
-				autoRun={sandPackProps.autoRun}
-				showNavigation={sandPackProps.showNavigation}
-			/>
+			<CodeEditor code={Example} />
 		</div>
 	);
 }

--- a/src/pages/Tree.jsx
+++ b/src/pages/Tree.jsx
@@ -1,8 +1,7 @@
-import { Sandpack } from "@codesandbox/sandpack-react";
+import CodeEditor from "../components/CodeEditor";
 
 import Example from "../examples/Tree/Example.js?raw";
-import index from "../examples/Tree/index.js?raw";
-import { sandPackOptions } from "../config/settings";
+
 
 function Tree() {
 	return (
@@ -26,20 +25,7 @@ function Tree() {
 				child contains values greater than the parent node.
 			</p>
 
-			<Sandpack
-				template="node"
-				theme="dark"
-				files={{
-					"Example.js": Example,
-					"index.js": index,
-				}}
-				customSetup={{
-					entry: index,
-				}}
-				autoRun={true}
-				options={sandPackOptions}
-				showNavigation={true}
-			/>
+			<CodeEditor code={Example} />
 		</div>
 	);
 }

--- a/src/workers/codeRunner.js
+++ b/src/workers/codeRunner.js
@@ -1,0 +1,33 @@
+self.onmessage = (e) => {
+    const { code } = e.data;
+    const logs = [];
+
+    const origLog = console.log;
+    const origWarn = console.warn;
+    const origError = console.error;
+
+    const capture = (...args) =>
+        logs.push(
+            args
+                .map((a) =>
+                    typeof a === "object" ? JSON.stringify(a, null, 2) : String(a)
+                )
+                .join(" ")
+        );
+
+    console.log = capture;
+    console.warn = capture;
+    console.error = capture;
+
+    try {
+        const stripped = code.replace(/export\s+default\s+/, "");
+        const result = new Function(`return (${stripped})();`)();
+        self.postMessage({ result: result !== undefined ? result : null, logs, error: null });
+    } catch (err) {
+        self.postMessage({ result: null, logs, error: err.message });
+    } finally {
+        console.log = origLog;
+        console.warn = origWarn;
+        console.error = origError;
+    }
+};


### PR DESCRIPTION
## Summary

- Replaces `@codesandbox/sandpack-react` with `@monaco-editor/react` across all 15 algorithm pages
- Adds a `CodeEditor` component (Monaco editor + preview panel) and a `codeRunner` Web Worker for fully local, offline code execution
- HTML output (Tree, Graphs, TowerHanoi) renders in a sandboxed `<iframe>`; plain values (Stack, MergeSort, etc.) render as formatted text
- Removes the CDN dependency on `sandpack-cdn.codesandbox.io` — motivated by CodeSandbox deprecating Sandpack
- Deletes `removeWatermark.js` (was only needed to hide the Sandpack "Open in CodeSandbox" button)

## Test plan

- [ ] Visit each algorithm page and confirm the editor loads with the example code
- [ ] Confirm the preview panel shows the correct output on load
- [ ] Edit code in the editor and confirm the preview auto-updates after ~500ms
- [ ] Check HTML-output pages (Tree, Graphs, TowerHanoi) render visually in the preview
- [ ] Check plain-output pages (Stack, MergeSort, QuickSort, etc.) show formatted text
- [ ] Confirm no network requests to `codesandbox.io` or `sandpack-cdn` in DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)